### PR TITLE
fix: resolve photo URL in engine, remove tg_bot_token from aiAnswer

### DIFF
--- a/aiConfig.yaml.example
+++ b/aiConfig.yaml.example
@@ -10,5 +10,4 @@ nebius_key: "..."
 nebius_url: "https://api.studio.nebius.ai/v1/"
 nebius_vision_model: "..."
 nebius_imagegen_model: "..."
-tg_bot_token: "..."     # needed to download photos from Telegram for vision
 sqlite_path: "/data/calarbot.db"

--- a/engine/runBot.go
+++ b/engine/runBot.go
@@ -107,7 +107,16 @@ func (b *Bot) RunBot() {
 			log.Printf("[%s] %s", update.Message.From.UserName, update.Message.Text)
 
 			// Find the module that should handle this message
-			payload := &botModules.Payload{Msg: update.Message, Extra: nil}
+			extra := map[string]interface{}{}
+			if msg := update.Message; len(msg.Photo) > 0 {
+				largest := msg.Photo[len(msg.Photo)-1]
+				if photoURL, err := bot.GetFileDirectURL(largest.FileID); err == nil {
+					extra["photo_url"] = photoURL
+				} else {
+					log.Printf("Failed to resolve photo URL: %v", err)
+				}
+			}
+			payload := &botModules.Payload{Msg: update.Message, Extra: extra}
 			var answer botModules.RichAnswer
 			var err error
 

--- a/modules/aiAnswer/handlers/vision.go
+++ b/modules/aiAnswer/handlers/vision.go
@@ -2,11 +2,7 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
@@ -16,28 +12,16 @@ type VisionClient interface {
 }
 
 type VisionHandler struct {
-	client    VisionClient
-	botToken  string
-	BotAPIURL string
+	client VisionClient
 }
 
-func NewVisionHandler(client VisionClient, botToken string) *VisionHandler {
-	return &VisionHandler{
-		client:    client,
-		botToken:  botToken,
-		BotAPIURL: "https://api.telegram.org",
-	}
+func NewVisionHandler(client VisionClient) *VisionHandler {
+	return &VisionHandler{client: client}
 }
 
-func (h *VisionHandler) Describe(ctx context.Context, msg *tgbotapi.Message) (string, error) {
-	if len(msg.Photo) == 0 {
-		return "", fmt.Errorf("no photo in message")
-	}
-	fileID := msg.Photo[len(msg.Photo)-1].FileID
-
-	fileURL, err := getTelegramFileURL(ctx, h.BotAPIURL, h.botToken, fileID)
-	if err != nil {
-		return "", fmt.Errorf("resolve telegram file: %w", err)
+func (h *VisionHandler) Describe(ctx context.Context, msg *tgbotapi.Message, photoURL string) (string, error) {
+	if photoURL == "" {
+		return "", fmt.Errorf("no photo URL provided")
 	}
 
 	prompt := msg.Text
@@ -47,32 +31,5 @@ func (h *VisionHandler) Describe(ctx context.Context, msg *tgbotapi.Message) (st
 	if prompt == "" {
 		prompt = "Describe this image in detail."
 	}
-	return h.client.DescribeImage(ctx, fileURL, prompt)
-}
-
-func getTelegramFileURL(ctx context.Context, botAPIURL, botToken, fileID string) (string, error) {
-	apiURL := fmt.Sprintf("%s/bot%s/getFile?file_id=%s",
-		botAPIURL, botToken, url.QueryEscape(fileID))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
-	if err != nil {
-		return "", err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-
-	var result struct {
-		OK          bool   `json:"ok"`
-		Description string `json:"description"`
-		Result      struct {
-			FilePath string `json:"file_path"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil || !result.OK {
-		return "", fmt.Errorf("getFile failed: %s (file_id %s)", result.Description, fileID)
-	}
-	return fmt.Sprintf("%s/file/bot%s/%s", botAPIURL, botToken, result.Result.FilePath), nil
+	return h.client.DescribeImage(ctx, photoURL, prompt)
 }

--- a/modules/aiAnswer/handlers/vision_test.go
+++ b/modules/aiAnswer/handlers/vision_test.go
@@ -2,9 +2,6 @@ package handlers_test
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -19,24 +16,13 @@ func (m *mockVision) DescribeImage(_ context.Context, _, _ string) (string, erro
 }
 
 func TestVisionHandlerDescribe(t *testing.T) {
-	// Fake Telegram getFile API
-	tgServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"ok":     true,
-			"result": map[string]string{"file_path": "photos/test.jpg"},
-		})
-	}))
-	defer tgServer.Close()
-
-	h := handlers.NewVisionHandler(&mockVision{"a fluffy cat"}, "fake-token")
-	h.BotAPIURL = tgServer.URL
-
+	h := handlers.NewVisionHandler(&mockVision{"a fluffy cat"})
 	msg := &tgbotapi.Message{
-		Text:  "what is this?",
-		Photo: []tgbotapi.PhotoSize{{FileID: "file123", Width: 100, Height: 100}},
+		Caption: "что это?",
+		Photo:   []tgbotapi.PhotoSize{{FileID: "file123", Width: 100, Height: 100}},
 	}
 
-	desc, err := h.Describe(context.Background(), msg)
+	desc, err := h.Describe(context.Background(), msg, "https://cdn.telegram.org/file/photos/test.jpg")
 	if err != nil {
 		t.Fatalf("Describe: %v", err)
 	}
@@ -45,11 +31,11 @@ func TestVisionHandlerDescribe(t *testing.T) {
 	}
 }
 
-func TestVisionHandlerNoPhoto(t *testing.T) {
-	h := handlers.NewVisionHandler(&mockVision{"irrelevant"}, "fake-token")
+func TestVisionHandlerNoPhotoURL(t *testing.T) {
+	h := handlers.NewVisionHandler(&mockVision{"irrelevant"})
 	msg := &tgbotapi.Message{Text: "hello"}
-	_, err := h.Describe(context.Background(), msg)
+	_, err := h.Describe(context.Background(), msg, "")
 	if err == nil {
-		t.Error("expected error for message with no photo")
+		t.Error("expected error when no photo URL provided")
 	}
 }

--- a/modules/aiAnswer/main.go
+++ b/modules/aiAnswer/main.go
@@ -29,7 +29,6 @@ type AIConfig struct {
 	CallWeight   int    `yaml:"call_weight"`
 	SystemPrompt string `yaml:"system_prompt"`
 	ContextSize  int    `yaml:"context_size"`
-	TgBotToken   string `yaml:"tg_bot_token"`
 
 	OpenRouterKey       string `yaml:"openrouter_key"`
 	NebiusKey           string `yaml:"nebius_key"`
@@ -89,7 +88,7 @@ func NewModule(order int, config AIConfig) *Module {
 		store:         s,
 		router:        router.New(orClient),
 		textHandler:   handlers.NewTextHandler(orClient, config.SystemPrompt),
-		visionHandler: handlers.NewVisionHandler(nbClient, config.TgBotToken),
+		visionHandler: handlers.NewVisionHandler(nbClient),
 		imageHandler:  handlers.NewImageGenHandler(nbClient),
 		cancelRefresh: cancel,
 	}
@@ -137,13 +136,15 @@ func (m *Module) Answer(payload *botModules.Payload) (botModules.RichAnswer, err
 		}
 	}
 
+	photoURL, _ := payload.Extra["photo_url"].(string)
+
 	if isDirectAddress(msg, m.config.BotUsername) {
 		route, err := m.router.Route(ctx, msg)
 		if err != nil {
 			log.Printf("router.Route error: %v", err)
 			route = router.RouteChat
 		}
-		return m.dispatch(ctx, route, msg, history)
+		return m.dispatch(ctx, route, msg, history, photoURL)
 	}
 
 	text, err := m.textHandler.Chat(ctx, msg, history)
@@ -154,10 +155,14 @@ func (m *Module) Answer(payload *botModules.Payload) (botModules.RichAnswer, err
 	return botModules.RichAnswer{Text: text}, nil
 }
 
-func (m *Module) dispatch(ctx context.Context, route router.Route, msg *tgbotapi.Message, history []store.ContextMessage) (botModules.RichAnswer, error) {
+func (m *Module) dispatch(ctx context.Context, route router.Route, msg *tgbotapi.Message, history []store.ContextMessage, photoURL string) (botModules.RichAnswer, error) {
 	switch route {
 	case router.RouteImageGen:
-		result, err := m.imageHandler.Generate(ctx, msg.Text)
+		prompt := msg.Text
+		if prompt == "" {
+			prompt = msg.Caption
+		}
+		result, err := m.imageHandler.Generate(ctx, prompt)
 		if err != nil {
 			log.Printf("imagegen error: %v", err)
 			return botModules.RichAnswer{Text: "Не удалось сгенерировать изображение"}, nil
@@ -165,7 +170,7 @@ func (m *Module) dispatch(ctx context.Context, route router.Route, msg *tgbotapi
 		return result, nil
 
 	case router.RouteVision:
-		text, err := m.visionHandler.Describe(ctx, msg)
+		text, err := m.visionHandler.Describe(ctx, msg, photoURL)
 		if err != nil {
 			log.Printf("vision error: %v", err)
 			return botModules.RichAnswer{Text: "Не удалось обработать изображение"}, nil


### PR DESCRIPTION
## Summary

- Engine теперь вызывает `bot.GetFileDirectURL()` и кладёт готовый URL фото в `payload.Extra["photo_url"]`
- Vision handler принимает URL как параметр — больше не ходит в Telegram API самостоятельно
- `tg_bot_token` убран из `AIConfig` и `aiConfig.yaml.example` — модуль не должен хранить токен бота
- `imagegen` теперь тоже берёт текст из `msg.Caption` если `msg.Text` пустой

## Test plan

- [ ] Собрать оба контейнера (engine + aiAnswer)
- [ ] Отправить фото с подписью `@calarbot что тут?` — должен ответить описанием через Nebius
- [ ] Убедиться что `tg_bot_token` убран из конфига и ничего не сломалось

🤖 Generated with [Claude Code](https://claude.com/claude-code)