### PR TITLE
chore: bump golang base image to 1.23, strip <think> from LLM responses

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 COPY common/ ./common/

--- a/modules/aiAnswer/Dockerfile
+++ b/modules/aiAnswer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 COPY common/ ./common/

--- a/modules/aiAnswer/models/openrouter.go
+++ b/modules/aiAnswer/models/openrouter.go
@@ -142,7 +142,24 @@ func (c *OpenRouterClient) Complete(ctx context.Context, system, user string) (s
 	if err != nil {
 		return "", err
 	}
-	return res.Choices[0].Message.Content, nil
+	return stripThinking(res.Choices[0].Message.Content), nil
+}
+
+// stripThinking removes <think>...</think> reasoning blocks emitted by some models.
+func stripThinking(s string) string {
+	for {
+		start := strings.Index(s, "<think>")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(s[start:], "</think>")
+		if end == -1 {
+			s = strings.TrimSpace(s[:start])
+			break
+		}
+		s = strings.TrimSpace(s[:start] + s[start+end+len("</think>"):])
+	}
+	return s
 }
 
 func (c *OpenRouterClient) Classify(ctx context.Context, text string) (router.Route, error) {

--- a/modules/sber/Dockerfile
+++ b/modules/sber/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 COPY common/ ./common/

--- a/modules/simpleReply/Dockerfile
+++ b/modules/simpleReply/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 COPY common/ ./common/

--- a/modules/skazka/Dockerfile
+++ b/modules/skazka/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 COPY common/ ./common/


### PR DESCRIPTION
## Summary

- Все Dockerfile'ы переведены с `golang:1.22-alpine` на `golang:1.23-alpine` (требование `modernc.org/sqlite`)
- Стриппинг `<think>...</think>` блоков из ответов LLM — некоторые модели (DeepSeek R1, Qwen QwQ и др.) выводят цепочку размышлений в `content`, теперь она убирается перед отправкой пользователю

## Test plan

- [ ] Пересобрать все контейнеры
- [ ] Убедиться что `<think>` теги не попадают в ответ в чат

🤖 Generated with [Claude Code](https://claude.com/claude-code)